### PR TITLE
Expose streaming API

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "7E6A5234F927C4B24F8054AB1E4572206C41F9E6D5C6C02273CB7531E7E5CED0" },
-  { name = "gleam_http", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "0A62451FC85B98062E0907659D92E6A89F5F3C0FBE4AB8046C99936BF6F91DBC" },
-  { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
-  { name = "gleeunit", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D33B7736CF0766ED3065F64A1EBB351E72B2E8DE39BAFC8ADA0E35E92A6A934F" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_http", version = "4.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "DD0271B32C356FB684EC7E9F48B1E835D0480168848581F68983C0CC371405D4" },
+  { name = "gleam_stdlib", version = "0.62.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0080706D3A5A9A36C40C68481D1D231D243AF602E6D2A2BE67BA8F8F4DFF45EC" },
+  { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
 ]
 
 [requirements]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "7E6A5234F927C4B24F8054AB1E4572206C41F9E6D5C6C02273CB7531E7E5CED0" },
-  { name = "gleam_http", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "0A62451FC85B98062E0907659D92E6A89F5F3C0FBE4AB8046C99936BF6F91DBC" },
-  { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
-  { name = "gleeunit", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D33B7736CF0766ED3065F64A1EBB351E72B2E8DE39BAFC8ADA0E35E92A6A934F" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_http", version = "4.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "FFE29C3832698AC3EF6202922EC534EE19540152D01A7C2D22CB97482E4AF211" },
+  { name = "gleam_stdlib", version = "0.63.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "962B25C667DA07F4CAB32001F44D3C41C1A89E58E3BBA54F183B482CF6122150" },
+  { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
 ]
 
 [requirements]

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,9 +3,9 @@
 
 packages = [
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
-  { name = "gleam_http", version = "4.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "FFE29C3832698AC3EF6202922EC534EE19540152D01A7C2D22CB97482E4AF211" },
-  { name = "gleam_stdlib", version = "0.63.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "962B25C667DA07F4CAB32001F44D3C41C1A89E58E3BBA54F183B482CF6122150" },
-  { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
+  { name = "gleam_http", version = "4.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "82EA6A717C842456188C190AFB372665EA56CE13D8559BF3B1DD9E40F619EE0C" },
+  { name = "gleam_stdlib", version = "0.68.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F7FAEBD8EF260664E86A46C8DBA23508D1D11BB3BCC6EE1B89B3BC3E5C83FF1E" },
+  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
 ]
 
 [requirements]

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,8 +3,8 @@
 
 packages = [
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
-  { name = "gleam_http", version = "4.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "DD0271B32C356FB684EC7E9F48B1E835D0480168848581F68983C0CC371405D4" },
-  { name = "gleam_stdlib", version = "0.62.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0080706D3A5A9A36C40C68481D1D231D243AF602E6D2A2BE67BA8F8F4DFF45EC" },
+  { name = "gleam_http", version = "4.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "FFE29C3832698AC3EF6202922EC534EE19540152D01A7C2D22CB97482E4AF211" },
+  { name = "gleam_stdlib", version = "0.63.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "962B25C667DA07F4CAB32001F44D3C41C1A89E58E3BBA54F183B482CF6122150" },
   { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
 ]
 

--- a/src/gleam/httpc.gleam
+++ b/src/gleam/httpc.gleam
@@ -45,26 +45,10 @@ type ErlOption {
   BodyFormat(BodyFormat)
   SocketOpts(List(SocketOpt))
   Sync(Bool)
-  Stream(Dynamic)
+  // {self, once}
+  Stream(#(Atom, Atom))
 }
 
-/// Streaming Options
-pub type Stream {
-  /// Buffer and deliver response in one final message.
-  /// This is the default streaming option
-  StreamNone
-  /// Deliver chunks to the calling process continuously.
-  StreamSelf
-  /// Deliver one chunk at a time to the calling process.
-  /// You must explicitly call httpc/async_stream_next() to
-  /// before receiving the next chunk.
-  StreamSelfOnce
-  /// Stream response body directly into a file.
-  StreamFile(String)
-}
-
-/// Stream response body directly into an I/O device (like standard_io).
-/// (Currently not supported)
 type SocketOpt {
   Ipfamily(Inet6fb4)
 }
@@ -136,54 +120,18 @@ pub fn send_bits(
   |> dispatch_bits(req)
 }
 
-// region:    --- asynchronous HTTP request
-// 
-
-// Utilities for converting between Dynamic and Gleam Types
-@external(erlang, "gleam_stdlib", "identity")
-fn atom_tuple_to_dynamic(t: #(Atom, Atom)) -> Dynamic
-
-@external(erlang, "gleam_stdlib", "identity")
-fn charlist_to_dynamic(t: Charlist) -> Dynamic
-
-/// When streaming to the calling process using `Stream(SelfOnce)`, the first
-/// stream message that is returned by `httpc.async_receive` is the `Dynamic`
-/// data `#(stream_start, #(headers, pid))` where `stream_start` is an `Atom`.
-/// This convenience function converts `headers` and `pid` to a tuple, of
-/// `List(#(Charlist, Charlist))` and `Pid` respectively for further
-/// processing by the caller.
-@external(erlang, "gleam_stdlib", "identity")
-pub fn dynamic_to_headers_pid(s: Dynamic) -> #(List(#(Charlist, Charlist)), Pid)
-
-/// When streaming to the calling process using `Stream(SelfOnce)`, the first
-/// stream message that is returned by `httpc.async_receive` is the `Dynamic`
-/// data `#(stream_start, headers)` This convenience function that converts
-/// `headers` to `List(#(Charlist, Charlist))` for further processing by the caller.
-@external(erlang, "gleam_stdlib", "identity")
-pub fn dynamic_to_headers(s: Dynamic) -> List(#(Charlist, Charlist))
-
-/// When streaming to the calling process using `Stream(SelfOnce)`, the second and
-/// often multiple consecutive stream messages that is returned by `httpc.async_receive`
-/// is the `Dynamic` data `#(stream, chunk)` This is a convenience function that converts
-/// `chunk` to a `BitArray` for further processing by the caller.
-@external(erlang, "gleam_stdlib", "identity")
-pub fn dynamic_to_bit_array(s: Dynamic) -> BitArray
-
-/// When streaming to the calling process using `Stream(None)`, the entire response
-/// is delivered in one final message, `#(stream_none, #(#(version, status, reason), headers, body))`.
-/// This is a convenience function that converts the `Dynamic` data represented by the second
-/// element of this tuple to `#(#(Charlist, Int, Charlist), List(#(Charlist, Charlist)), BitArray)`
-/// for further processing by the caller.
-@external(erlang, "gleam_stdlib", "identity")
-pub fn dynamic_to_response(
-  s: Dynamic,
-) -> #(#(Charlist, Int, Charlist), List(#(Charlist, Charlist)), BitArray)
-
-@external(erlang, "gleam_httpc_ffi", "stream_next")
-fn stream_next(pid: Pid) -> Result(Nil, Nil)
+// TODO: refine error type
+/// Send an asynchronous HTTP request of binary data using the default configuration.
+///
+/// If you wish to use some other configuration use `async_dispatch_bits` instead.
+///
+pub fn async_send_bits(req: Request(BitArray)) -> Result(Reference, HttpError) {
+  configure()
+  |> async_dispatch_bits(req)
+}
 
 // TODO: refine error type
-/// Send a asyncrhonous HTTP request of binary data
+/// Send an asynchronous HTTP request of binary data
 pub fn async_dispatch_bits(
   config: Configuration,
   req: Request(BitArray),
@@ -203,25 +151,11 @@ pub fn async_dispatch_bits(
     False -> [Ssl([Verify(VerifyNone)]), ..erl_http_options]
   }
   let erl_options = [
-    Sync(False),
     BodyFormat(Binary),
     SocketOpts([Ipfamily(Inet6fb4)]),
+    Sync(False),
+    Stream(#(atom.create("self"), atom.create("once"))),
   ]
-  let self = atom.create("self")
-  let once = atom.create("once")
-  let erl_options = case config.stream {
-    StreamNone -> [Stream(atom.to_dynamic(atom.create("none"))), ..erl_options]
-    StreamSelf -> [Stream(atom.to_dynamic(self)), ..erl_options]
-    StreamSelfOnce -> [
-      Stream(atom_tuple_to_dynamic(#(self, once))),
-      ..erl_options
-    ]
-    StreamFile(filename) -> [
-      Stream(charlist_to_dynamic(charlist.from_string(filename))),
-      ..erl_options
-    ]
-  }
-
   use request_id <- result.try(
     case req.method {
       http.Options | http.Head | http.Get -> {
@@ -249,47 +183,70 @@ pub fn async_dispatch_bits(
   Ok(request_id)
 }
 
-// Receive a message that has been sent the the current process using a
-// `NamedSubject`. In this case the subject name is `http`
-@external(erlang, "gleam_httpc_ffi", "receive")
-fn receive(req_id: Reference, timeout: Int) -> Result(#(Atom, Dynamic), Atom)
-
-/// Receive an ansynchronous stream message to the process designated by the
-/// `request_id`.  For a description of those messages, see the documentation for
-/// `httpc.async_stream`. The Dynamic data response may be decoded by the caller
-/// using the convenience functions `httpc.dynamic_to_header_pid`,
-/// `httpc.dynamic_to_header`, and `httpc.dynamic_to_bit_array`
-/// TODO: Refine Error
-pub fn async_receive(
+@external(erlang, "gleam_httpc_ffi", "receive_stream_start")
+fn stream_start(
   req_id: Reference,
   timeout: Int,
-) -> Result(#(Atom, Dynamic), HttpError) {
+) -> Result(#(List(#(Charlist, Charlist)), Pid), Dynamic)
+
+@external(erlang, "gleam_httpc_ffi", "receive_stream_chunk")
+fn stream_chunk(req_id: Reference, timeout: Int) -> Result(BitArray, Dynamic)
+
+@external(erlang, "gleam_httpc_ffi", "receive_stream_end")
+fn stream_end(
+  req_id: Reference,
+  timeout: Int,
+) -> Result(List(#(Charlist, Charlist)), Dynamic)
+
+/// Triggers the next asynchronous streaming message to be sent to the calling process
+/// designated by `pid`. 
+@external(erlang, "gleam_httpc_ffi", "stream_next")
+pub fn stream_next(pid: Pid) -> Result(Nil, Nil)
+
+/// Receive an ansynchronous `stream_start` message to the process designated
+/// by the `request_id`.  The function returns the headers, and a process id
+/// 
+/// This process id is used as an argument to `httpc.stream_next(pid)` to trigger
+/// the next message to be sent to the calling process
+pub fn receive_stream_start(
+  req_id: Reference,
+  timeout: Int,
+) -> Result(#(List(#(Charlist, Charlist)), Pid), HttpError) {
   use response <- result.try(
-    receive(req_id, timeout)
-    |> result.map_error(with: fn(reason) {
-      case atom.to_string(reason) {
-        "timeout" -> ResponseTimeout
-        _ -> InvalidUtf8Response
-      }
-    }),
+    stream_start(req_id, timeout)
+    |> result.map_error(normalise_error),
   )
   Ok(response)
 }
 
-///  Call this function when using the `Stream` option `StreamOnce`
-///  It triggers the next message to be sent to the calling process designated by
-/// `pid`. 
-pub fn async_stream_next(pid: Pid) -> Result(Nil, HttpError) {
-  use _next <- result.try(
-    // TODO return reason somehow? {http, {ReqId, {error, Reason}}}
-    stream_next(pid) |> result.replace_error(InvalidUtf8Response),
+/// Receive an ansynchronous `stream` body part message to the process designated
+/// by the `request_id`.
+pub fn receive_stream_chunk(
+  req_id: Reference,
+  timeout: Int,
+) -> Result(BitArray, HttpError) {
+  use response <- result.try(
+    stream_chunk(req_id, timeout)
+    |> result.map_error(normalise_error),
   )
-  Ok(Nil)
+  Ok(response)
 }
 
-// endregion: --- asynchronous http request
-
-// region:    --- synchronous http request
+/// Receive an ansynchronous `stream_end` message to the process designated
+/// by the `request_id`.
+///
+/// Notice that chunked encoding can add headers so that there are more headers
+/// in the `stream_end` message than in `stream_start`.
+pub fn receive_stream_end(
+  req_id: Reference,
+  timeout: Int,
+) -> Result(List(#(Charlist, Charlist)), HttpError) {
+  use response <- result.try(
+    stream_end(req_id, timeout)
+    |> result.map_error(normalise_error),
+  )
+  Ok(response)
+}
 
 // TODO: refine error type
 /// Send a HTTP request of binary data.
@@ -338,8 +295,6 @@ pub fn dispatch_bits(
   Ok(Response(status, list.map(headers, string_header), resp_body))
 }
 
-// endregion: --- synchronous request
-
 /// Configuration that can be used to send HTTP requests.
 ///
 /// To be used with `dispatch` and `dispatch_bits`.
@@ -362,12 +317,6 @@ pub opaque type Configuration {
     /// Timeout for the request in milliseconds.
     ///
     timeout: Int,
-    /// Used to set the streaming options when streaming asynchronously to the
-    /// calling process.
-    /// 
-    /// Default is `StreamNone`, which buffers and send the entire response
-    /// in one final message.
-    stream: Stream,
   )
 }
 
@@ -379,16 +328,8 @@ pub opaque type Configuration {
 /// - Redirects are not followed.
 /// - The timeout for the response to be received is 30 seconds from when the
 ///   request is sent.
-/// - Requests are synchronous by default. However, when sending asychronous
-///   HTTP requests, the default stream option is `StreamNone`, which buffers
-///   and sends the entire response in one final message.
 pub fn configure() -> Configuration {
-  Builder(
-    verify_tls: True,
-    follow_redirects: False,
-    timeout: 30_000,
-    stream: StreamNone,
-  )
+  Builder(verify_tls: True, follow_redirects: False, timeout: 30_000)
 }
 
 /// Set whether to verify the TLS certificate of the server.
@@ -418,27 +359,6 @@ pub fn timeout(config: Configuration, timeout: Int) -> Configuration {
   Builder(..config, timeout:)
 }
 
-/// Set the type of asychronous(i.e, streaming) HTTP request.
-/// 
-/// When streaming to the calling process using the option `StreamSelf`, the following
-/// stream messages are sent to that process: `#(http, #(RequestId, stream_start, Headers)`,
-/// `#(http, #(RequestId, stream, BinBodyPart))`, and `#(http, (RequestId, stream_end, Headers))`.  
-/// 
-/// When streaming to the calling processes using option `StreamSelfOnce`, the first
-/// message has an extra element, `Pid`.  That is, `#(http, #(RequestId, stream_start, Headers, Pid))`.
-/// This is the process id to be used as an argument to `httpc.stream_next(pid: Pid)` to trigger the
-/// next message to be sent to the calling process. Notice that chunked encoding can add headers
-/// so that there are more headers in the stream_end message than in stream_start.
-/// 
-/// When streaming to a file, using the option `Stream(filename)`, the message
-/// `#(http, #(RequestId, saved_to_file))` is sent.
-/// 
-/// Default strem option is `StreamNone`, which means buffer and send the entire response in one final message.
-/// 
-pub fn async_stream(config: Configuration, which: Stream) -> Configuration {
-  Builder(..config, stream: which)
-}
-
 /// Send a synchronus HTTP request of unicode data.
 ///
 pub fn dispatch(
@@ -461,11 +381,7 @@ pub fn async_dispatch(
   request: Request(String),
 ) -> Result(Reference, HttpError) {
   let request = request.map(request, bit_array.from_string)
-  use request_id <- result.try(
-    async_dispatch_bits(config, request)
-    // TODO Is this the right error? Should I create a unique streaming error?
-    |> result.replace_error(InvalidUtf8Response),
-  )
+  use request_id <- result.try(async_dispatch_bits(config, request))
   Ok(request_id)
 }
 

--- a/src/gleam/httpc.gleam
+++ b/src/gleam/httpc.gleam
@@ -1,6 +1,9 @@
 import gleam/bit_array
 import gleam/dynamic.{type Dynamic}
+import gleam/erlang/atom.{type Atom}
 import gleam/erlang/charlist.{type Charlist}
+import gleam/erlang/process.{type Pid}
+import gleam/erlang/reference.{type Reference}
 import gleam/http.{type Method}
 import gleam/http/request.{type Request}
 import gleam/http/response.{type Response, Response}
@@ -41,8 +44,27 @@ type BodyFormat {
 type ErlOption {
   BodyFormat(BodyFormat)
   SocketOpts(List(SocketOpt))
+  Sync(Bool)
+  Stream(Dynamic)
 }
 
+/// Streaming Options
+pub type Stream {
+  /// Buffer and deliver response in one final message.
+  /// This is the default streaming option
+  StreamNone
+  /// Deliver chunks to the calling process continuously.
+  StreamSelf
+  /// Deliver one chunk at a time to the calling process.
+  /// You must explicitly call httpc/async_stream_next() to
+  /// before receiving the next chunk.
+  StreamSelfOnce
+  /// Stream response body directly into a file.
+  StreamFile(String)
+}
+
+/// Stream response body directly into an I/O device (like standard_io).
+/// (Currently not supported)
 type SocketOpt {
   Ipfamily(Inet6fb4)
 }
@@ -81,6 +103,22 @@ fn erl_request_no_body(
   Dynamic,
 )
 
+@external(erlang, "httpc", "request")
+fn erl_request_async_no_body(
+  a: Method,
+  b: #(Charlist, List(#(Charlist, Charlist))),
+  c: List(ErlHttpOption),
+  d: List(ErlOption),
+) -> Result(Reference, Dynamic)
+
+@external(erlang, "httpc", "request")
+fn erl_request_async(
+  a: Method,
+  b: #(Charlist, List(#(Charlist, Charlist)), Charlist, BitArray),
+  c: List(ErlHttpOption),
+  d: List(ErlOption),
+) -> Result(Reference, Dynamic)
+
 fn string_header(header: #(Charlist, Charlist)) -> #(String, String) {
   let #(k, v) = header
   #(charlist.to_string(k), charlist.to_string(v))
@@ -97,6 +135,161 @@ pub fn send_bits(
   configure()
   |> dispatch_bits(req)
 }
+
+// region:    --- asynchronous HTTP request
+// 
+
+// Utilities for converting between Dynamic and Gleam Types
+@external(erlang, "gleam_stdlib", "identity")
+fn atom_tuple_to_dynamic(t: #(Atom, Atom)) -> Dynamic
+
+@external(erlang, "gleam_stdlib", "identity")
+fn charlist_to_dynamic(t: Charlist) -> Dynamic
+
+/// When streaming to the calling process using `Stream(SelfOnce)`, the first
+/// stream message that is returned by `httpc.async_receive` is the `Dynamic`
+/// data `#(stream_start, #(headers, pid))` where `stream_start` is an `Atom`.
+/// This convenience function converts `headers` and `pid` to a tuple, of
+/// `List(#(Charlist, Charlist))` and `Pid` respectively for further
+/// processing by the caller.
+@external(erlang, "gleam_stdlib", "identity")
+pub fn dynamic_to_headers_pid(s: Dynamic) -> #(List(#(Charlist, Charlist)), Pid)
+
+/// When streaming to the calling process using `Stream(SelfOnce)`, the first
+/// stream message that is returned by `httpc.async_receive` is the `Dynamic`
+/// data `#(stream_start, headers)` This convenience function that converts
+/// `headers` to `List(#(Charlist, Charlist))` for further processing by the caller.
+@external(erlang, "gleam_stdlib", "identity")
+pub fn dynamic_to_headers(s: Dynamic) -> List(#(Charlist, Charlist))
+
+/// When streaming to the calling process using `Stream(SelfOnce)`, the second and
+/// often multiple consecutive stream messages that is returned by `httpc.async_receive`
+/// is the `Dynamic` data `#(stream, chunk)` This is a convenience function that converts
+/// `chunk` to a `BitArray` for further processing by the caller.
+@external(erlang, "gleam_stdlib", "identity")
+pub fn dynamic_to_bit_array(s: Dynamic) -> BitArray
+
+/// When streaming to the calling process using `Stream(None)`, the entire response
+/// is delivered in one final message, `#(stream_none, #(#(version, status, reason), headers, body))`.
+/// This is a convenience function that converts the `Dynamic` data represented by the second
+/// element of this tuple to `#(#(Charlist, Int, Charlist), List(#(Charlist, Charlist)), BitArray)`
+/// for further processing by the caller.
+@external(erlang, "gleam_stdlib", "identity")
+pub fn dynamic_to_response(
+  s: Dynamic,
+) -> #(#(Charlist, Int, Charlist), List(#(Charlist, Charlist)), BitArray)
+
+@external(erlang, "gleam_httpc_ffi", "stream_next")
+fn stream_next(pid: Pid) -> Result(Nil, Nil)
+
+// TODO: refine error type
+/// Send a asyncrhonous HTTP request of binary data
+pub fn async_dispatch_bits(
+  config: Configuration,
+  req: Request(BitArray),
+) -> Result(Reference, HttpError) {
+  let erl_url =
+    req
+    |> request.to_uri
+    |> uri.to_string
+    |> charlist.from_string
+  let erl_headers = prepare_headers(req.headers)
+  let erl_http_options = [
+    Autoredirect(config.follow_redirects),
+    Timeout(config.timeout),
+  ]
+  let erl_http_options = case config.verify_tls {
+    True -> erl_http_options
+    False -> [Ssl([Verify(VerifyNone)]), ..erl_http_options]
+  }
+  let erl_options = [
+    Sync(False),
+    BodyFormat(Binary),
+    SocketOpts([Ipfamily(Inet6fb4)]),
+  ]
+  let self = atom.create("self")
+  let once = atom.create("once")
+  let erl_options = case config.stream {
+    StreamNone -> [Stream(atom.to_dynamic(atom.create("none"))), ..erl_options]
+    StreamSelf -> [Stream(atom.to_dynamic(self)), ..erl_options]
+    StreamSelfOnce -> [
+      Stream(atom_tuple_to_dynamic(#(self, once))),
+      ..erl_options
+    ]
+    StreamFile(filename) -> [
+      Stream(charlist_to_dynamic(charlist.from_string(filename))),
+      ..erl_options
+    ]
+  }
+
+  use request_id <- result.try(
+    case req.method {
+      http.Options | http.Head | http.Get -> {
+        let erl_req = #(erl_url, erl_headers)
+        erl_request_async_no_body(
+          req.method,
+          erl_req,
+          erl_http_options,
+          erl_options,
+        )
+      }
+      _ -> {
+        let erl_content_type =
+          req
+          |> request.get_header("content-type")
+          |> result.unwrap("application/octet-stream")
+          |> charlist.from_string
+        let erl_req = #(erl_url, erl_headers, erl_content_type, req.body)
+        erl_request_async(req.method, erl_req, erl_http_options, erl_options)
+      }
+    }
+    |> result.map_error(normalise_error),
+  )
+
+  Ok(request_id)
+}
+
+// Receive a message that has been sent the the current process using a
+// `NamedSubject`. In this case the subject name is `http`
+@external(erlang, "gleam_httpc_ffi", "receive")
+fn receive(req_id: Reference, timeout: Int) -> Result(#(Atom, Dynamic), Atom)
+
+/// Receive an ansynchronous stream message to the process designated by the
+/// `request_id`.  For a description of those messages, see the documentation for
+/// `httpc.async_stream`. The Dynamic data response may be decoded by the caller
+/// using the convenience functions `httpc.dynamic_to_header_pid`,
+/// `httpc.dynamic_to_header`, and `httpc.dynamic_to_bit_array`
+/// TODO: Refine Error
+pub fn async_receive(
+  req_id: Reference,
+  timeout: Int,
+) -> Result(#(Atom, Dynamic), HttpError) {
+  use response <- result.try(
+    receive(req_id, timeout)
+    |> result.map_error(with: fn(reason) {
+      case atom.to_string(reason) {
+        "timeout" -> ResponseTimeout
+        _ -> InvalidUtf8Response
+      }
+    }),
+  )
+  Ok(response)
+}
+
+///  Call this function when using the `Stream` option `StreamOnce`
+///  It triggers the next message to be sent to the calling process designated by
+/// `pid`. 
+pub fn async_stream_next(pid: Pid) -> Result(Nil, HttpError) {
+  use _next <- result.try(
+    // TODO return reason somehow? {http, {ReqId, {error, Reason}}}
+    stream_next(pid) |> result.replace_error(InvalidUtf8Response),
+  )
+  Ok(Nil)
+}
+
+// endregion: --- asynchronous http request
+
+// region:    --- synchronous http request
 
 // TODO: refine error type
 /// Send a HTTP request of binary data.
@@ -141,8 +334,11 @@ pub fn dispatch_bits(
   )
 
   let #(#(_version, status, _status), headers, resp_body) = response
+
   Ok(Response(status, list.map(headers, string_header), resp_body))
 }
+
+// endregion: --- synchronous request
 
 /// Configuration that can be used to send HTTP requests.
 ///
@@ -166,6 +362,12 @@ pub opaque type Configuration {
     /// Timeout for the request in milliseconds.
     ///
     timeout: Int,
+    /// Used to set the streaming options when streaming asynchronously to the
+    /// calling process.
+    /// 
+    /// Default is `StreamNone`, which buffers and send the entire response
+    /// in one final message.
+    stream: Stream,
   )
 }
 
@@ -177,9 +379,16 @@ pub opaque type Configuration {
 /// - Redirects are not followed.
 /// - The timeout for the response to be received is 30 seconds from when the
 ///   request is sent.
-///
+/// - Requests are synchronous by default. However, when sending asychronous
+///   HTTP requests, the default stream option is `StreamNone`, which buffers
+///   and sends the entire response in one final message.
 pub fn configure() -> Configuration {
-  Builder(verify_tls: True, follow_redirects: False, timeout: 30_000)
+  Builder(
+    verify_tls: True,
+    follow_redirects: False,
+    timeout: 30_000,
+    stream: StreamNone,
+  )
 }
 
 /// Set whether to verify the TLS certificate of the server.
@@ -209,7 +418,28 @@ pub fn timeout(config: Configuration, timeout: Int) -> Configuration {
   Builder(..config, timeout:)
 }
 
-/// Send a HTTP request of unicode data.
+/// Set the type of asychronous(i.e, streaming) HTTP request.
+/// 
+/// When streaming to the calling process using the option `StreamSelf`, the following
+/// stream messages are sent to that process: `#(http, #(RequestId, stream_start, Headers)`,
+/// `#(http, #(RequestId, stream, BinBodyPart))`, and `#(http, (RequestId, stream_end, Headers))`.  
+/// 
+/// When streaming to the calling processes using option `StreamSelfOnce`, the first
+/// message has an extra element, `Pid`.  That is, `#(http, #(RequestId, stream_start, Headers, Pid))`.
+/// This is the process id to be used as an argument to `httpc.stream_next(pid: Pid)` to trigger the
+/// next message to be sent to the calling process. Notice that chunked encoding can add headers
+/// so that there are more headers in the stream_end message than in stream_start.
+/// 
+/// When streaming to a file, using the option `Stream(filename)`, the message
+/// `#(http, #(RequestId, saved_to_file))` is sent.
+/// 
+/// Default strem option is `StreamNone`, which means buffer and send the entire response in one final message.
+/// 
+pub fn async_stream(config: Configuration, which: Stream) -> Configuration {
+  Builder(..config, stream: which)
+}
+
+/// Send a synchronus HTTP request of unicode data.
 ///
 pub fn dispatch(
   config: Configuration,
@@ -222,6 +452,31 @@ pub fn dispatch(
     Ok(body) -> Ok(response.set_body(resp, body))
     Error(_) -> Error(InvalidUtf8Response)
   }
+}
+
+/// Send a asynchronus HTTP request of unicode data.
+///
+pub fn async_dispatch(
+  config: Configuration,
+  request: Request(String),
+) -> Result(Reference, HttpError) {
+  let request = request.map(request, bit_array.from_string)
+  use request_id <- result.try(
+    async_dispatch_bits(config, request)
+    // TODO Is this the right error? Should I create a unique streaming error?
+    |> result.replace_error(InvalidUtf8Response),
+  )
+  Ok(request_id)
+}
+
+// TODO: refine error type
+/// Send a HTTP asychronous request of unicode data using the default configuration.
+///
+/// If you wish to use some other configuration use `async_dispatch` instead.
+///
+pub fn async_send(req: Request(String)) -> Result(Reference, HttpError) {
+  configure()
+  |> async_dispatch(req)
 }
 
 // TODO: refine error type

--- a/src/gleam/httpc.gleam
+++ b/src/gleam/httpc.gleam
@@ -1,6 +1,10 @@
 import gleam/bit_array
+
 import gleam/dynamic.{type Dynamic}
+import gleam/erlang/atom
 import gleam/erlang/charlist.{type Charlist}
+import gleam/erlang/process
+import gleam/erlang/reference.{type Reference}
 import gleam/http.{type Method}
 import gleam/http/request.{type Request}
 import gleam/http/response.{type Response, Response}
@@ -38,9 +42,19 @@ type BodyFormat {
   Binary
 }
 
+type Destination {
+  Self
+}
+
+type Mode {
+  Once
+}
+
 type ErlOption {
   BodyFormat(BodyFormat)
   SocketOpts(List(SocketOpt))
+  Sync(Bool)
+  Stream(#(Destination, Mode))
 }
 
 type SocketOpt {
@@ -57,6 +71,21 @@ type ErlSslOption {
 
 type ErlVerifyOption {
   VerifyNone
+}
+
+pub type HttpSocket
+
+type Headers =
+  List(#(String, String))
+
+type RequestId =
+  Reference
+
+pub type StreamMessage {
+  StreamStart(RequestId, Headers, process.Pid)
+  StreamChunk(RequestId, BitArray)
+  StreamEnd(RequestId, Headers)
+  StreamError(RequestId, HttpError)
 }
 
 @external(erlang, "httpc", "request")
@@ -81,6 +110,22 @@ fn erl_request_no_body(
   Dynamic,
 )
 
+@external(erlang, "httpc", "request")
+fn erl_request_async_no_body(
+  a: Method,
+  b: #(Charlist, List(#(Charlist, Charlist))),
+  c: List(ErlHttpOption),
+  d: List(ErlOption),
+) -> Result(Reference, Dynamic)
+
+@external(erlang, "httpc", "request")
+fn erl_request_async(
+  a: Method,
+  b: #(Charlist, List(#(Charlist, Charlist)), Charlist, BitArray),
+  c: List(ErlHttpOption),
+  d: List(ErlOption),
+) -> Result(Reference, Dynamic)
+
 fn string_header(header: #(Charlist, Charlist)) -> #(String, String) {
   let #(k, v) = header
   #(charlist.to_string(k), charlist.to_string(v))
@@ -96,6 +141,103 @@ pub fn send_bits(
 ) -> Result(Response(BitArray), HttpError) {
   configure()
   |> dispatch_bits(req)
+}
+
+/// Send an asynchronous HTTP request of binary data using the default configuration.
+///
+/// If you wish to use some other configuration use `async_dispatch_bits` instead.
+///
+pub fn async_send_bits(req: Request(BitArray)) -> Result(Reference, HttpError) {
+  configure()
+  |> async_dispatch_bits(req)
+}
+
+/// Send an asynchronous HTTP request of binary data
+/// 
+pub fn async_dispatch_bits(
+  config: Configuration,
+  req: Request(BitArray),
+) -> Result(Reference, HttpError) {
+  let erl_url =
+    req
+    |> request.to_uri
+    |> uri.to_string
+    |> charlist.from_string
+  let erl_headers = prepare_headers(req.headers)
+  let erl_http_options = [
+    Autoredirect(config.follow_redirects),
+    Timeout(config.timeout),
+  ]
+  let erl_http_options = case config.verify_tls {
+    True -> erl_http_options
+    False -> [Ssl([Verify(VerifyNone)]), ..erl_http_options]
+  }
+  let erl_options = [
+    BodyFormat(Binary),
+    SocketOpts([Ipfamily(Inet6fb4)]),
+    Sync(False),
+    Stream(#(Self, Once)),
+  ]
+  use request_id <- result.try(
+    case req.method {
+      http.Options | http.Head | http.Get -> {
+        let erl_req = #(erl_url, erl_headers)
+        erl_request_async_no_body(
+          req.method,
+          erl_req,
+          erl_http_options,
+          erl_options,
+        )
+      }
+      _ -> {
+        let erl_content_type =
+          req
+          |> request.get_header("content-type")
+          |> result.unwrap("application/octet-stream")
+          |> charlist.from_string
+        let erl_req = #(erl_url, erl_headers, erl_content_type, req.body)
+        erl_request_async(req.method, erl_req, erl_http_options, erl_options)
+      }
+    }
+    |> result.map_error(normalise_error),
+  )
+
+  Ok(request_id)
+}
+
+@external(erlang, "gleam_httpc_ffi", "stream_next")
+pub fn stream_next(pid: process.Pid) -> Result(Nil, Nil)
+
+@external(erlang, "gleam_httpc_ffi", "coerce_stream_message")
+fn unsafe_decode(msg: Dynamic) -> StreamMessage
+
+fn map_stream_message(mapper: fn(StreamMessage) -> t) -> fn(Dynamic) -> t {
+  fn(message) { mapper(unsafe_decode(message)) }
+}
+
+fn select_stream_messages(
+  selector: process.Selector(t),
+  mapper: fn(StreamMessage) -> t,
+) -> process.Selector(t) {
+  let http = atom.create("http")
+
+  selector
+  |> process.select_record(http, 1, map_stream_message(mapper))
+}
+
+/// Initialize asychronous streaming by confiquring a selector to receive stream messages.
+///
+/// Note this will receive messages from all processes that sent an asychronous
+/// HTTP request; for example using `async_send`, rather than any specific one.
+/// In this case, for finer grained processing, you can filter on the request_id,
+/// which is the first argument in the `StreamMessage` constructor.
+/// If you wish to only handle stream messages from one process, then use one
+/// process per asychronous HTTP request. 
+///
+pub fn initialize_stream_selector() -> process.Selector(StreamMessage) {
+  let handle = fn(msg: StreamMessage) { msg }
+  process.new_selector()
+  |> select_stream_messages(handle)
 }
 
 // TODO: refine error type
@@ -141,6 +283,7 @@ pub fn dispatch_bits(
   )
 
   let #(#(_version, status, _status), headers, resp_body) = response
+
   Ok(Response(status, list.map(headers, string_header), resp_body))
 }
 
@@ -177,7 +320,6 @@ pub opaque type Configuration {
 /// - Redirects are not followed.
 /// - The timeout for the response to be received is 30 seconds from when the
 ///   request is sent.
-///
 pub fn configure() -> Configuration {
   Builder(verify_tls: True, follow_redirects: False, timeout: 30_000)
 }
@@ -209,7 +351,7 @@ pub fn timeout(config: Configuration, timeout: Int) -> Configuration {
   Builder(..config, timeout:)
 }
 
-/// Send a HTTP request of unicode data.
+/// Send a synchronus HTTP request of unicode data.
 ///
 pub fn dispatch(
   config: Configuration,
@@ -224,7 +366,26 @@ pub fn dispatch(
   }
 }
 
-// TODO: refine error type
+/// Send a asynchronus HTTP request of unicode data.
+///
+pub fn async_dispatch(
+  config: Configuration,
+  request: Request(String),
+) -> Result(Reference, HttpError) {
+  let request = request.map(request, bit_array.from_string)
+  use request_id <- result.try(async_dispatch_bits(config, request))
+  Ok(request_id)
+}
+
+/// Send a HTTP asychronous request of unicode data using the default configuration.
+///
+/// If you wish to use some other configuration use `async_dispatch` instead.
+///
+pub fn async_send(req: Request(String)) -> Result(Reference, HttpError) {
+  configure()
+  |> async_dispatch(req)
+}
+
 /// Send a HTTP request of unicode data using the default configuration.
 ///
 /// If you wish to use some other configuration use `dispatch` instead.

--- a/src/gleam_httpc_ffi.erl
+++ b/src/gleam_httpc_ffi.erl
@@ -1,5 +1,50 @@
 -module(gleam_httpc_ffi).
--export([default_user_agent/0, normalise_error/1]).
+-export([default_user_agent/0, normalise_error/1, stream_next/1, 'receive'/2]).
+%% -export([default_user_agent/0, normalise_error/1, stream_next/1, 'receive'/2, stream_to_file/0]).
+
+%% stream_to_file() ->
+%%     Url = "https://postman-echo.com/stream/5",
+%%     Filename = tmpfile("httpc_stream_test"),
+%%     %% Asynchronous request; body streamed to file by httpc
+%%     {ok, ReqId} =
+%%         httpc:request(
+%%           get,
+%%           {Url, []},
+%%           [],  %% HTTP options
+%%           [{sync, false}, {stream, Filename}]  %% client options
+%%         ).
+
+%% tmpfile(Prefix) ->
+%%     Dir = case os:getenv("TMPDIR") of false -> "/tmp"; D -> D end,
+%%     Name = io_lib:format("~s~p.bin", [Prefix, erlang:unique_integer([monotonic, positive])]),
+%%     filename:join(Dir, lists:flatten(Name)).
+%%====================================================================
+%% Streaming
+%%====================================================================
+ %% Helper: call stream_next with whatever the handler expects
+stream_next(HandlerPid) when is_pid(HandlerPid) ->
+ case httpc:stream_next(HandlerPid) of
+   ok -> {ok, nil};
+   _  -> {error, nil}
+ end.
+
+'receive'(ReqId, Timeout) ->
+   receive
+     {http, {ReqId, stream_start, Headers}} -> {ok, {stream_start, Headers}};
+     {http, {ReqId, stream_start, Headers, Pid}} -> {ok, {stream_start, {Headers, Pid}}};
+     {http, {ReqId, stream, Chunk}} -> {ok, {stream, Chunk}};
+     {http, {ReqId, stream_end, EndInfo}} -> {ok, {stream_end, EndInfo}};
+     {http, {ReqId, saved_to_file}} -> {ok, {saved_to_file, nil}};
+     {http, {ReqId, {{Version, Status, Reason}, Headers, Body}}} -> {ok, {stream_none, {{Version, Status, Reason}, Headers, Body}}};
+     {http, {ReqId, {error, Reason}}} -> {error, Reason}
+   after Timeout ->
+     {error, timeout}
+   end.
+    
+
+%%====================================================================
+%% Error normalization
+%%====================================================================
 
 normalise_error(Error = {failed_connect, Opts}) ->
     Ipv6 = case lists:keyfind(inet6, 1, Opts) of

--- a/test/gleam_httpc_test.gleam
+++ b/test/gleam_httpc_test.gleam
@@ -1,7 +1,9 @@
+import gleam/erlang/atom
 import gleam/http.{Get, Head, Options}
 import gleam/http/request
 import gleam/http/response
 import gleam/httpc
+import gleam/io
 import gleam/string
 import gleeunit
 
@@ -160,4 +162,108 @@ pub fn timeout_error_test() {
     |> httpc.timeout(200)
     |> httpc.dispatch(req)
     == Error(httpc.ResponseTimeout)
+}
+
+pub fn async_stream_self_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("postman-echo.com")
+    |> request.set_path("/stream/1")
+
+  let config =
+    httpc.configure()
+    |> httpc.async_stream(httpc.StreamSelf)
+
+  let assert Ok(request_id) = httpc.async_dispatch(config, req)
+
+  let assert Ok(response) = httpc.async_receive(request_id, 10_000)
+
+  // stream_start
+  // #(stream_start, headers) 
+  let #(stream_start, _headers) = response
+  assert atom.to_string(stream_start) == "stream_start"
+
+  // stream - 1 chunk
+  // #(stream, chunk) 
+  let assert Ok(response) = httpc.async_receive(request_id, 10_000)
+  let #(stream, _chunk) = response
+  assert atom.to_string(stream) == "stream"
+
+  // stream_end
+  // #(stream, end_info) 
+  let assert Ok(response) = httpc.async_receive(request_id, 10_000)
+  let #(stream_end, _end_info) = response
+  assert atom.to_string(stream_end) == "stream_end"
+}
+
+pub fn async_stream_self_once_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("postman-echo.com")
+    |> request.set_path("/stream/1")
+
+  let config =
+    httpc.configure()
+    |> httpc.async_stream(httpc.StreamSelfOnce)
+
+  let assert Ok(request_id) = httpc.async_dispatch(config, req)
+
+  // stream_start
+  // #(stream_start, headers, pid) 
+  let assert Ok(response) = httpc.async_receive(request_id, 10_000)
+  let #(stream_start, headers_pid) = response
+  assert atom.to_string(stream_start) == "stream_start"
+  let #(_headers, pid) = httpc.dynamic_to_headers_pid(headers_pid)
+
+  // stream - 1 chunks
+  // #(stream_start, chunk) 
+  let assert Ok(_) = httpc.async_stream_next(pid)
+  let assert Ok(response) = httpc.async_receive(request_id, 10_000)
+  let #(stream, _chunk) = response
+  assert atom.to_string(stream) == "stream"
+
+  // stream_end
+  // #(stream_start, end_info) 
+  let assert Ok(_) = httpc.async_stream_next(pid)
+  let assert Ok(response) = httpc.async_receive(request_id, 10_000)
+  let #(stream_end, _end_info) = response
+  assert atom.to_string(stream_end) == "stream_end"
+}
+
+pub fn async_stream_file_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("postman-echo.com")
+    |> request.set_path("/stream/5")
+
+  let config =
+    httpc.configure()
+    |> httpc.async_stream(httpc.StreamFile("/tmp/http_stream_test.json"))
+
+  let assert Ok(request_id) = httpc.async_dispatch(config, req)
+
+  let assert Ok(response) = httpc.async_receive(request_id, 1000)
+  let #(saved_to_file, _) = response
+  assert atom.to_string(saved_to_file) == "saved_to_file"
+}
+
+pub fn async_stream_none_test() {
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("postman-echo.com")
+    |> request.set_path("/stream/5")
+
+  let config =
+    httpc.configure()
+    |> httpc.async_stream(httpc.StreamNone)
+
+  let assert Ok(request_id) = httpc.async_dispatch(config, req)
+
+  let assert Ok(response) = httpc.async_receive(request_id, 1000)
+  let #(stream_none, _rest) = response
+  assert atom.to_string(stream_none) == "stream_none"
 }


### PR DESCRIPTION
# Expose Streaming API

## Motivation

Erlang's [inets](https://www.erlang.org/docs/26/apps/inets/) application provides a set of Internet-related services, including the HTTP client `httpc`. The `httpc` module gives users the option to stream the body of a 200 or 206 response either to the calling process or directly to a file.  

This pull request exposes that option to `gleam_httpc` while maintaining **full backward compatibility**. It supports the stated use case `stream:{self, once}`, (i.e., streaming chunks) represented by the custom type `Stream`:

```gleam
type Destination {
  Self
}

type Mode {
  Once
}

type ErlOption {
  ...
  Stream(#(Destination, Mode))
}

```
None of the other streaming APIs from the Erlang httpc module is supported (e.g., stream:{filename}).

## Implementation Details

Several functions that have synchronous equivalents were added to support streaming, including:

* `dispatch_stream_bits(config: Configuration, req: Request(BitArray))` - similar to `dispatch_bits` function,  send a HTTP stream request of binary data
* `dispatch_stream_request(config: Configuration, req: Request(String))` - similar to the`dispatch` function, send a HTTP stream request of unicode data
*  `send_stream_request(req: Request(String)` - similar to the `send` function, send an HTTP stream request of Unicode data using the default configuration.

The function `select_stream_messages` configures a selector to receive stream messages.   Finally, the function `receive_next_stream_message(pid: Pid)` triggers the next streaming message to be sent to the calling process designated by `pid`. 
  
## Testing

Added two new unit tests, `send_stream_request_test`, and `dispatch_stream_request_test` using the [postman streamed response api](https://www.postman.com/postman/postman-public-workspace/request/8sqcxxz/streamed-response)

## Documentation

* Updated README.md with a `stream:{self, once}` example
* Added inline documentation to new public functions 

### Related Issues

* Resolves Issue #31
