### PR TITLE
Show case weird timeout

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "7E6A5234F927C4B24F8054AB1E4572206C41F9E6D5C6C02273CB7531E7E5CED0" },
-  { name = "gleam_http", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "0A62451FC85B98062E0907659D92E6A89F5F3C0FBE4AB8046C99936BF6F91DBC" },
-  { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
-  { name = "gleeunit", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D33B7736CF0766ED3065F64A1EBB351E72B2E8DE39BAFC8ADA0E35E92A6A934F" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_http", version = "4.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "82EA6A717C842456188C190AFB372665EA56CE13D8559BF3B1DD9E40F619EE0C" },
+  { name = "gleam_stdlib", version = "0.67.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "6368313DB35963DC02F677A513BB0D95D58A34ED0A9436C8116820BF94BE3511" },
+  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
 ]
 
 [requirements]

--- a/test/gleam_httpc_test.gleam
+++ b/test/gleam_httpc_test.gleam
@@ -1,3 +1,4 @@
+import gleam/list
 import gleam/http.{Get, Head, Options}
 import gleam/http/request
 import gleam/http/response
@@ -160,4 +161,23 @@ pub fn timeout_error_test() {
     |> httpc.timeout(200)
     |> httpc.dispatch(req)
     == Error(httpc.ResponseTimeout)
+}
+
+pub fn httpc_timeout_test() {
+  list.range(1, 100)
+  |> list.each(fn(iteration) {
+    echo iteration
+
+    let req =
+      request.new()
+      |> request.set_method(Get)
+      |> request.set_scheme(http.Https)
+      |> request.set_host("iconify.github.io")
+      |> request.set_path("/icon-sets/json/fluent-emoji.json")
+
+    assert httpc.configure()
+      |> httpc.timeout(600000) //10 minutes
+      |> httpc.dispatch(req)
+      != Error(httpc.ResponseTimeout)
+  })
 }


### PR DESCRIPTION
I'm building a library to deal with Iconify's icon sets in Gleam. I ported its types from Typescript to Gleam and added accompanying json encoders. What better way to test them than using real world data crossed my mind. I wrote an integration test that downloads each icon set in their collection and verifies whether it round trips. In doing so, I encountered a weird error I can't explain. It's as if the timeout specified has no effect. I hope it's a PEBKAC issue. In this PR I added a minimal repro (as a test) that "fails on my machine" ... after a while (took 19 iterations on my machine). The observation is that the code fails with a timeout well before the specified timeout, but only after a few iterations. It's a different "sort of timeout" though. Does the gleeunit test fx come with its own timeout per test perhaps?

```gleam
gleeunit.main
An unexpected error occurred:

  [Id([1, 12]), Reason(Timeout(dict.from_list([#(Stacktrace, [Httpc(HandleAnswer, 5, [File(charlist.from_string("httpc.erl")), Line(1277)]), Httpc(HandleRequest, 9, [File(charlist.from_string("httpc.erl")), Line(1220)]), #(atom.create("gleam@httpc"), DispatchBits, 2, [File(charlist.from_string("src/gleam/httpc.gleam")), Line(150)]), #(atom.create("gleam@httpc"), Dispatch, 2, [File(charlist.from_string("src/gleam/httpc.gleam")), Line(222)]), GleamHttpcTest(atom.create("-httpc_timeout_test/0-anonymous-0-"), 1, [File(charlist.from_string("test/gleam_httpc_test.gleam")), Line(190)]), #(atom.create("gleam@list"), Each, 2, [File(charlist.from_string("src/gleam/list.gleam")), Line(1787)]), EunitTest(atom.create("-mf_wrapper/2-fun-0-"), 2, [File(charlist.from_string("eunit_test.erl")), Line(285)]), EunitTest(RunTestfun, 1, [File(charlist.from_string("eunit_test.erl")), Line(83)])])]))), Desc(Undefined), Source(GleamHttpcTest(HttpcTimeoutTest, 0)), Line(0)]
  
gleeunit.main
An unexpected error occurred:

  [Id([1]), Reason(Undefined), Desc("module 'gleam_httpc_test'"), Spawn(Undefined), Order(Undefined)]
```